### PR TITLE
Disable ubuntu dist-packages in server_test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,10 +16,19 @@ py_binary(
     ],
 )
 
+py_library(
+    name = "unittest_path_cleaner",
+    srcs = ["test/unittest_path_cleaner.py"],
+)
+
 py_test(
     name = "server_test",
     srcs = ["test/server_test.py"],
     data = [":server"],
+    deps = [
+        ":unittest_path_cleaner",
+        "@requirements_numpy//:pkg",
+    ],
 )
 
 pycodestyle_test(
@@ -28,6 +37,7 @@ pycodestyle_test(
         "bazel",
         "server.py",
         "test/server_test.py",
+        "test/unittest_path_cleaner.py",
     ],
 )
 

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+import test.unittest_path_cleaner  # Disable Ubuntu packages.
+
 from pathlib import Path
 import signal
 import socket
 import subprocess
 import time
 import unittest
+
+import numpy as np
 
 
 class ServerTest(unittest.TestCase):

--- a/test/unittest_path_cleaner.py
+++ b/test/unittest_path_cleaner.py
@@ -1,0 +1,5 @@
+# Ignore Ubuntu-installed packages during local testing, so we fail-fast when
+# there are missing `deps = []` in the BUILD file.
+import sys
+ubuntu_paths = [x for x in sys.path if x.endswith("/dist-packages")]  # noqa
+[sys.path.remove(x) for x in ubuntu_paths]  # noqa


### PR DESCRIPTION
Use `numpy` to demonstrate efficacy.

+@zachfang for review, please.

If you rebase #17 atop this, you should be able to see the CI failures locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-blender/19)
<!-- Reviewable:end -->
