### PR TITLE
Find the server port before connecting

### DIFF
--- a/test/server_test.py
+++ b/test/server_test.py
@@ -5,10 +5,11 @@ import test.unittest_path_cleaner  # Disable Ubuntu packages.
 import datetime
 import os
 from pathlib import Path
+import re
 import shutil
 import signal
-import socket
 import subprocess
+import sys
 import time
 import unittest
 
@@ -27,18 +28,30 @@ DEFAULT_GLTF_FILE = "test/two_rgba_boxes.gltf"
 
 class ServerTest(unittest.TestCase):
     def setUp(self):
-        # Find and launch the server in the background.
+        # Start the server on the other process. Bind to port 0 and let the OS
+        # assign an available port later on.
         server_path = Path("server").absolute().resolve()
-        self.server_proc = subprocess.Popen([server_path])
+        server_args = [
+            server_path,
+            "--host=127.0.0.1",
+            "--port=0",
+        ]
+        self.server_proc = subprocess.Popen(
+            server_args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        # Wait to hear which port it's using.
+        self.server_port = None
         start_time = time.time()
         while time.time() < start_time + 30.0:
-            with socket.socket() as s:
-                try:
-                    s.connect(("127.0.0.1", 8000))
-                    # Success!
-                    break
-                except ConnectionRefusedError as e:
-                    time.sleep(0.1)
+            line = self.server_proc.stdout.readline().decode("utf-8")
+            print(f"[server] {line}", file=sys.stderr, end="")
+            match = re.search(r"Running on http://127.0.0.1:([0-9]+)", line)
+            if match:
+                (self.server_port,) = match.groups()
+                break
         else:
             self.fail("Could not connect after 30 seconds")
 
@@ -117,7 +130,7 @@ class ServerTest(unittest.TestCase):
         with open(gltf_path, "rb") as scene:
             form_data = self._create_request_form(image_type=image_type)
             response = requests.post(
-                url="http://127.0.0.1:8000/render",
+                url=f"http://127.0.0.1:{self.server_port}/render",
                 data=form_data,
                 files={"scene": scene},
                 stream=True,


### PR DESCRIPTION
As we added more and more tests into our `server_test.py`, I started to see different tests fighting for the same port, i.e., 8000, and then failing. This PR took the server spawn-up workflow in our `RenderEngineGltfClient` to find the port the server is using before connecting.

For example:
```
* Serving Flask app 'drake_render_gltf_blender'
 * Debug mode: off
Address already in use
Port 8000 is in use by another program. Either identify and stop that program, or start the server with a different port.
Failed to create /home/runner/.cache/mesa_shader_cache for shader cache (Read-only file system)---disabling.
Traceback (most recent call last):
  File "/home/runner/.cache/bazel/_bazel_runner/05c7d00ef03c4a[80](https://github.com/RobotLocomotion/drake-blender/actions/runs/4915832051/jobs/8778809410#step:7:81)5a0e98609341b41d/sandbox/linux-sandbox/4/execroot/__main__/bazel-out/k8-fastbuild/bin/examples/ball_bin_test.runfiles/__main__/examples/ball_bin.py", line 201, in <module>
    main()
  File "/home/runner/.cache/bazel/_bazel_runner/05c7d00ef03c4a805a0e98609341b41d/sandbox/linux-sandbox/4/execroot/__main__/bazel-out/k8-fastbuild/bin/examples/ball_bin_test.runfiles/__main__/examples/ball_bin.py", line 1[84](https://github.com/RobotLocomotion/drake-blender/actions/runs/4915832051/jobs/8778809410#step:7:85), in main
    _run(args)
  File "/home/runner/.cache/bazel/_bazel_runner/05c7d00ef03c4a805a0e9[86](https://github.com/RobotLocomotion/drake-blender/actions/runs/4915832051/jobs/8778809410#step:7:87)09341b41d/sandbox/linux-sandbox/4/execroot/__main__/bazel-out/k8-fastbuild/bin/examples/ball_bin_test.runfiles/__main__/examples/ball_bin.py", line 150, in _run
    simulator.AdvanceTo(1e-3)
RuntimeError: RenderClient: error from POST:
  URL:             http://127.0.0.1:8000/render
  Service Message: Failure when receiving data from the peer
  HTTP Code:       0
  Server Message:  None.
```

---

Closes #23.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-blender/24)
<!-- Reviewable:end -->
