### PR TITLE
Force resolution_percentage to 100%

### DIFF
--- a/server.py
+++ b/server.py
@@ -143,6 +143,7 @@ class Blender:
         scene.render.filepath = str(output_path)
         scene.render.resolution_x = params.width
         scene.render.resolution_y = params.height
+        scene.render.resolution_percentage = 100
         aspect_ratio = params.focal_y / params.focal_x
         scene.render.pixel_aspect_x = 1.0
         scene.render.pixel_aspect_y = aspect_ratio


### PR DESCRIPTION
One of the sample `*.blend` files I tried somehow set this to 200%, causing RPC errors when Drake rejected the rendered image as being too large by 2x.

(For the moment, I consider this a WIP because I don't immediately have any regression test case.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-blender/29)
<!-- Reviewable:end -->
