### PR TITLE
Add buildifier linting

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,11 +2,11 @@
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
-load(":defs.bzl", "py_lint_test")
+load(":defs.bzl", "bazel_lint_test", "py_lint_test")
 
 exports_files([
     "pyproject.toml",
-    "server.py"
+    "server.py",
 ])
 
 py_binary(
@@ -51,6 +51,59 @@ py_test(
     ],
 )
 
+config_setting(
+    name = "darwin-amd64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "darwin-arm64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
+    name = "linux-amd64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "linux-arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+alias(
+    name = "buildifier",
+    actual = select({
+        ":darwin-amd64": "@buildifier-darwin-amd64//file:downloaded",
+        ":darwin-arm64": "@buildifier-darwin-arm64//file:downloaded",
+        ":linux-amd64": "@buildifier-linux-amd64//file:downloaded",
+        ":linux-arm64": "@buildifier-linux-arm64//file:downloaded",
+        "//conditions:default": "@platforms//:incompatible",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+bazel_lint_test(
+    name = "bazel_lint_test",
+    srcs = [
+        "BUILD.bazel",
+        "WORKSPACE.bazel",
+        "defs.bzl",
+    ],
+)
+
 py_lint_test(
     name = "py_lint_test",
     srcs = [
@@ -66,8 +119,8 @@ py_binary(
     testonly = True,
     srcs = ["@test_requirements_black//:rules_python_wheel_entry_point_black.py"],
     main = "@test_requirements_black//:rules_python_wheel_entry_point_black.py",
-    deps = ["@test_requirements_black//:rules_python_wheel_entry_point_black"],
     tags = ["manual"],
+    deps = ["@test_requirements_black//:rules_python_wheel_entry_point_black"],
 )
 
 compile_pip_requirements(

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -44,6 +44,36 @@ pip_parse(
     requirements_lock = "//examples:requirements.txt",
 )
 
+[
+    http_file(
+        name = name,
+        executable = True,
+        sha256 = sha256,
+        url = "https://github.com/bazelbuild/buildtools/releases/download/{}/{}".format(
+            "v6.1.2",
+            name,
+        ),
+    )
+    for name, sha256 in [
+        (
+            "buildifier-darwin-amd64",
+            "e2f4a67691c5f55634fbfb3850eb97dd91be0edd059d947b6c83d120682e0216",
+        ),
+        (
+            "buildifier-darwin-arm64",
+            "7549b5f535219ac957aa2a6069d46fbfc9ea3f74abd85fd3d460af4b1a2099a6",
+        ),
+        (
+            "buildifier-linux-amd64",
+            "51bc947dabb7b14ec6fb1224464fbcf7a7cb138f1a10a3b328f00835f72852ce",
+        ),
+        (
+            "buildifier-linux-arm64",
+            "0ba6e8e3208b5a029164e542ddb5509e618f87b639ffe8cc2f54770022853080",
+        ),
+    ]
+]
+
 load("@examples_requirements//:requirements.bzl", "install_deps")
 
 install_deps()
@@ -53,6 +83,7 @@ install_deps()
 # https://twitter.com/limarest_art.
 http_file(
     name = "color_attribute_painting",
+    sha256 = "443b213229a4c863b2015beff623a700886c14928707a2fb24a6dd85fd80a207",
     urls = [
         base + "/demo/sculpt_mode/color_attribute_painting.blend"
         for base in [
@@ -60,5 +91,4 @@ http_file(
             "https://mirror.clarkson.edu/blender",
         ]
     ],
-    sha256 = "443b213229a4c863b2015beff623a700886c14928707a2fb24a6dd85fd80a207",
 )

--- a/defs.bzl
+++ b/defs.bzl
@@ -2,7 +2,8 @@
 
 load("@rules_python//python:defs.bzl", "py_test")
 
-def py_lint_test(name, srcs, *, use_black=True, use_codestyle=True):
+def py_lint_test(name, srcs, *, use_black = True, use_codestyle = True):
+    """Adds Python linter checks for the given `srcs`."""
     native.filegroup(
         name = "_{}_data".format(name),
         srcs = srcs,
@@ -17,7 +18,7 @@ def py_lint_test(name, srcs, *, use_black=True, use_codestyle=True):
         tags = ["lint", "pycodestyle"],
         deps = [
             "@test_requirements_pycodestyle//:rules_python_wheel_entry_point_pycodestyle",
-        ]
+        ],
     )
     (not use_black) or py_test(
         name = "black_{}".format(name),
@@ -37,5 +38,20 @@ def py_lint_test(name, srcs, *, use_black=True, use_codestyle=True):
         tags = ["lint", "black"],
         deps = [
             "@test_requirements_black//:rules_python_wheel_entry_point_black",
-        ]
+        ],
+    )
+
+def bazel_lint_test(name, srcs):
+    """Adds Bazel linter checks for the given `srcs`."""
+    locations = [
+        "$(location {})".format(src)
+        for src in srcs
+    ]
+    native.sh_test(
+        name = name,
+        size = "small",
+        srcs = ["//:buildifier"],
+        data = srcs,
+        args = ["-mode=check"] + locations,
+        tags = ["lint"],
     )

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
-load("//:defs.bzl", "py_lint_test")
+load("//:defs.bzl", "bazel_lint_test", "py_lint_test")
 
 exports_files(glob(["**"]))
 
@@ -28,6 +28,13 @@ py_test(
     data = [
         ":ball_bin",
         ":test/bpy_use_cycles.py",
+    ],
+)
+
+bazel_lint_test(
+    name = "bazel_lint_test",
+    srcs = [
+        "BUILD.bazel",
     ],
 )
 

--- a/fix_lint.sh
+++ b/fix_lint.sh
@@ -8,6 +8,10 @@ set -eu -o pipefail
 me=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
 cd $(dirname "$me")
 
+./bazel run //:buildifier \
+    *.bazel \
+    *.bzl \
+    */*.bazel
 ./bazel build //:black
 ./.bazel/bin/black \
     bazel \


### PR DESCRIPTION
Fix existing lint.

Towards #25.

See https://github.com/bazelbuild/buildtools/issues/367 for the upstream request to provide the workspace rule to fetch a binary on demand, without all of the mumbo jumbo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-blender/45)
<!-- Reviewable:end -->
