### PR TITLE
Update how server distinguishes betweeen glTF and blender assets

### DIFF
--- a/test/one_rgba_box.gltf
+++ b/test/one_rgba_box.gltf
@@ -157,7 +157,7 @@
       },
       {
          "children" : [ 0, 1 ],
-         "name" : "Renderer Node"
+         "name" : "Root Node"
       }
    ],
    "scene" : 0,

--- a/test/two_rgba_boxes.gltf
+++ b/test/two_rgba_boxes.gltf
@@ -254,7 +254,7 @@
          "name" : "Camera Node"
       },
       {
-         "children" : [ 0, 1, 2 ],
+         "children" : [ 1, 2 ],
          "name" : "Renderer Node"
       }
    ],
@@ -263,7 +263,7 @@
    [
       {
          "name" : "Layer 0",
-         "nodes" : [ 3 ]
+         "nodes" : [ 0, 3 ]
       }
    ]
 }


### PR DESCRIPTION
Rather than keying on data contained within the .glTF file, server takes responsibility for all objects added by importing the glTF. Specifically, put them in a special collection and distinguish nodes based on whether they are in or out of the collection.

It also cleans up the orientation correction so that the point around which the imported content gets rotated is explicitly the world origin (and not any blender-inferred origin).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-blender/53)
<!-- Reviewable:end -->
