### PR TITLE
One bug fix, one optimization

### DIFF
--- a/server.py
+++ b/server.py
@@ -123,14 +123,12 @@ class Blender:
         """
         Renders the current scene with the given parameters.
         """
-        # Always reset the scene to start with.
-        self.reset_scene()
-
         # Load the blend file to set up the basic scene if provided; otherwise,
-        # a default lighting is added.
+        # the scene gets reset with default lighting.
         if self._blend_file is not None:
             bpy.ops.wm.open_mainfile(filepath=str(self._blend_file))
         else:
+            self.reset_scene()
             self.add_default_light_source()
 
         # Apply the user's custom settings.
@@ -183,7 +181,7 @@ class Blender:
         if camera is None:
             _logger.error(
                 "Camera node not found. Check the input glTF file "
-                f"'{params.input_path}'."
+                f"'{params.scene}'."
             )
             return
 


### PR DESCRIPTION
Bug
 - The error message in the case where the imported glTF file is missing the expected camera referenced a non-existent variable.

Fix
 - There's no reason to reset *and* open a .blend file. So, we only reset if there's no blender file. It saves a fraction of a second.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-blender/63)
<!-- Reviewable:end -->
