### PR TITLE
Support pip installation more sensibly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,3 +93,13 @@ jobs:
         with:
           path: ~/.cache/bazel_ci
           key: bazel_ci-${{ github.ref }}-${{ github.run_number }}-${{ github.run_attempt }}
+  install_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - run: pip install .
+      - run: drake-blender-server --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "drake-blender"
-version = "0.2.1"
+version = "0.2.1.dev0"
 # NOTE TO MAINTAINERS: when editing this list, you must copy the identical
 # update into requirements.in as well.
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,10 @@ line-length = 79
 profile = "black"
 force_sort_within_sections = true
 line_length = 79
+
+[project]
+name = "drake-blender"
+version = "0.2.1"
+
+[project.scripts]
+drake-blender-server = "server:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@
 [project]
 name = "drake-blender"
 version = "0.2.1"
+# NOTE TO MAINTAINERS: when editing this list, you must copy the identical
+# update into requirements.in as well.
 dependencies = [
     "bpy==3.6.0",
     "flask"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,17 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Contains configuration settings for linting Python.
 
+[project]
+name = "drake-blender"
+version = "0.2.1"
+dependencies = [
+    "bpy==3.6.0",
+    "flask"
+]
+
+[project.scripts]
+drake-blender-server = "server:main"
+
 [tool.black]
 line-length = 79
 
@@ -8,10 +19,3 @@ line-length = 79
 profile = "black"
 force_sort_within_sections = true
 line_length = 79
-
-[project]
-name = "drake-blender"
-version = "0.2.1"
-
-[project.scripts]
-drake-blender-server = "server:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-2-Clause
-# Contains configuration settings for linting Python.
 
 [project]
 name = "drake-blender"

--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,12 @@
 # To compile this file into requirements.txt, run:
 # ./tools/upgrade.sh
 
+# NOTE TO MAINTAINERS: when editing this file, you must copy the identical
+# update into pyproject.toml as well.
+#
+# TODO(jwnimmer-tri) Figure out how to keep only a single copy of our list
+# of dependencies.
+
 # TODO(jwnimmer-tri) When upgrading to blender 4.0, we'll need to figure out
 # how to make depth and label images work correctly.
 bpy==3.6.0


### PR DESCRIPTION
As of `v0.2.0`, installing this repository into a Python virtual environment drops `server.py` into `<venv>/lib/python3.x/site-packages` but does not create an executable for the script that is conveniently callable (without Bazel). Thus, users must run the following, somewhat long, command to run the server using Python:

```bash
source <venv>/bin/activate
python3 <venv>/lib/python3.10/site-packages/server.py ...
```

This PR adds a few lines to the `pyproject.toml` file to install an executable to the virtual environment `bin` directory that launches the server. Now, the following command launches the server in a more convenient fashion:

```bash
source <venv>/bin/activate
drake-blender-server ...
```

Note, this PR introduces some potentially breaking changes:
- The name of the generated wheel changes from `server-0.0.0` to `drake_blender-0.2.1`
  - In order to set `[project.scripts]` to install the executable, you must also set `[project]`.
  - When you set `[project]`, you must specify the name of the project. I set this to `drake-blender`, which ultimately propagates to the name of the wheel
  - I also set the version to a patch change beyond the latest tagged version
- The name of the executable is `drake-blender-server` (none previously existed)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-blender/116)
<!-- Reviewable:end -->
