### PR TITLE
[ci] Use a python_version variable so renovate won't touch it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,11 +95,14 @@ jobs:
           key: bazel_ci-${{ github.ref }}-${{ github.run_number }}-${{ github.run_attempt }}
   install_test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ["3.10"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python_version }}
           cache: "pip"
       - run: pip install .
       - run: drake-blender-server --help


### PR DESCRIPTION
See https://github.com/RobotLocomotion/drake-blender/pull/123 for what we're trying to avoid here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-blender/128)
<!-- Reviewable:end -->
