### PR TITLE
Allow ball_bin to run its full two seconds

### DIFF
--- a/examples/ball_bin.py
+++ b/examples/ball_bin.py
@@ -94,7 +94,9 @@ def _run(args):
     # Create the scene.
     builder = DiagramBuilder()
     plant, scene_graph = AddMultibodyPlant(
-        config=MultibodyPlantConfig(), builder=builder
+        config=MultibodyPlantConfig(
+            discrete_contact_approximation="similar",
+        ), builder=builder
     )
     added_models = ProcessModelDirectives(
         directives=ModelDirectives(directives=scenario.directives), plant=plant


### PR DESCRIPTION
Some under-the-hood change in configuration has caused the simulation to fail (at about t=0.421s). Swapping the contact approximation from the implicitly set default value of "lagged" to "similar" allows the simulation to run its full duration.

To see the crash, remove the change and simply run:

`bazel run //examples:ball_bin`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-blender/143)
<!-- Reviewable:end -->
